### PR TITLE
Update Rustls dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2018"
 
 [dependencies]
 futures-io = "0.3"
-rustls = "0.20"
-webpki = "0.22"
+rustls = "0.21"
+webpki = { version = "0.100", package = "rustls-webpki" }
 
 [features]
 early-data = []


### PR DESCRIPTION
This updates `rustls` to v0.21 and `webpki` to `rustls-webpki` with version 0.100.