### PR TITLE
Make it possible to use futures-rustls without ring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,14 @@ edition = "2018"
 
 [dependencies]
 futures-io = "0.3"
-rustls = "0.22"
+rustls = { version = "0.22", default-features = false, features = ["tls12"] }
 pki-types = { package = "rustls-pki-types", version = "1" }
 
 [features]
+default = ["ring"]
 early-data = []
+ring = ["rustls/ring"]
+aws-lc-rs = ["rustls/aws_lc_rs"]
 
 [dev-dependencies]
 smol = "1"
@@ -25,4 +28,4 @@ futures-util = { version = "0.3.1", features = [ "io" ] }
 lazy_static = "1"
 rustls-pemfile = "2"
 webpki-roots = "0.26"
-webpki = { version = "0.102", package = "rustls-webpki" }
+webpki = { version = "0.102", package = "rustls-webpki", default-features = false }


### PR DESCRIPTION
Add a default-enabled feature `ring` that passes throuh to
`rustls/ring`. This preserves compatibility with existing users of
futures-rustls. Disabling this feature allows using futures-rustls with
other crypto providers.

Add a non-default `aws-lc-rs` feature, as well, for convenience of users
who depend on futures-rustls but don't need to depend on rustls
directly, so they don't have to add a rustls dependency just to set the
feature.

The testsuite currently still requires ring to be enabled, as it calls
functions like `ClientConfig::builder()`.
