### PR TITLE
feat: updates for rustls 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,17 @@ edition = "2018"
 
 [dependencies]
 futures-io = "0.3"
-rustls = { version = "0.22", default-features = false, features = ["tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["std"] }
 pki-types = { package = "rustls-pki-types", version = "1" }
 
 [features]
-default = ["ring"]
-early-data = []
-ring = ["rustls/ring"]
+default = ["aws-lc-rs", "tls12", "logging"]
 aws-lc-rs = ["rustls/aws_lc_rs"]
+early-data = []
+fips = ["rustls/fips"]
+logging = ["rustls/logging"]
+ring = ["rustls/ring"]
+tls12 = ["rustls/tls12"]
 
 [dev-dependencies]
 smol = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ pki-types = { package = "rustls-pki-types", version = "1" }
 [features]
 default = ["aws-lc-rs", "tls12", "logging"]
 aws-lc-rs = ["rustls/aws_lc_rs"]
+aws_lc_rs = ["aws-lc-rs"]
 early-data = []
 fips = ["rustls/fips"]
 logging = ["rustls/logging"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,5 @@
 use super::*;
 use crate::common::IoSession;
-#[cfg(unix)]
-use std::os::unix::io::{AsRawFd, RawFd};
-#[cfg(windows)]
-use std::os::windows::io::{AsRawSocket, RawSocket};
 
 /// A wrapper around an underlying raw stream which implements the TLS or SSL
 /// protocol.

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,6 +30,72 @@ impl<IO> TlsStream<IO> {
     }
 }
 
+#[cfg(feature = "early-data")]
+fn poll_handle_early_data<IO>(
+    state: &mut TlsState,
+    stream: &mut Stream<IO, ClientConnection>,
+    early_waker: &mut Option<std::task::Waker>,
+    cx: &mut Context<'_>,
+    bufs: &[io::IoSlice<'_>],
+) -> Poll<io::Result<usize>>
+where
+    IO: AsyncRead + AsyncWrite + Unpin,
+{
+    if let TlsState::EarlyData(pos, data) = state {
+        use std::io::Write;
+
+        // write early data
+        if let Some(mut early_data) = stream.session.early_data() {
+            let mut written = 0;
+
+            for buf in bufs {
+                if buf.is_empty() {
+                    continue;
+                }
+
+                let len = match early_data.write(buf) {
+                    Ok(0) => break,
+                    Ok(n) => n,
+                    Err(err) => return Poll::Ready(Err(err)),
+                };
+
+                written += len;
+                data.extend_from_slice(&buf[..len]);
+
+                if len < buf.len() {
+                    break;
+                }
+            }
+
+            if written != 0 {
+                return Poll::Ready(Ok(written));
+            }
+        }
+
+        // complete handshake
+        while stream.session.is_handshaking() {
+            ready!(stream.handshake(cx))?;
+        }
+
+        // write early data (fallback)
+        if !stream.session.is_early_data_accepted() {
+            while *pos < data.len() {
+                let len = ready!(stream.as_mut_pin().poll_write(cx, &data[*pos..]))?;
+                *pos += len;
+            }
+        }
+
+        // end
+        *state = TlsState::Stream;
+
+        if let Some(waker) = early_waker.take() {
+            waker.wake();
+        }
+    }
+
+    Poll::Ready(Ok(0))
+}
+
 #[cfg(unix)]
 impl<S> AsRawFd for TlsStream<S>
 where
@@ -141,48 +207,47 @@ where
         let mut stream =
             Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
 
-        #[allow(clippy::match_single_binding)]
-        match this.state {
-            #[cfg(feature = "early-data")]
-            TlsState::EarlyData(ref mut pos, ref mut data) => {
-                use std::io::Write;
-
-                // write early data
-                if let Some(mut early_data) = stream.session.early_data() {
-                    let len = match early_data.write(buf) {
-                        Ok(n) => n,
-                        Err(err) => return Poll::Ready(Err(err)),
-                    };
-                    if len != 0 {
-                        data.extend_from_slice(&buf[..len]);
-                        return Poll::Ready(Ok(len));
-                    }
-                }
-
-                // complete handshake
-                while stream.session.is_handshaking() {
-                    ready!(stream.handshake(cx))?;
-                }
-
-                // write early data (fallback)
-                if !stream.session.is_early_data_accepted() {
-                    while *pos < data.len() {
-                        let len = ready!(stream.as_mut_pin().poll_write(cx, &data[*pos..]))?;
-                        *pos += len;
-                    }
-                }
-
-                // end
-                this.state = TlsState::Stream;
-
-                if let Some(waker) = this.early_waker.take() {
-                    waker.wake();
-                }
-
-                stream.as_mut_pin().poll_write(cx, buf)
+        #[cfg(feature = "early-data")]
+        {
+            let bufs = [io::IoSlice::new(buf)];
+            let written = ready!(poll_handle_early_data(
+                &mut this.state,
+                &mut stream,
+                &mut this.early_waker,
+                cx,
+                &bufs
+            ))?;
+            if written != 0 {
+                return Poll::Ready(Ok(written));
             }
-            _ => stream.as_mut_pin().poll_write(cx, buf),
         }
+        stream.as_mut_pin().poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        let mut stream =
+            Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
+
+        #[cfg(feature = "early-data")]
+        {
+            let written = ready!(poll_handle_early_data(
+                &mut this.state,
+                &mut stream,
+                &mut this.early_waker,
+                cx,
+                bufs
+            ))?;
+            if written != 0 {
+                return Poll::Ready(Ok(written));
+            }
+        }
+
+        stream.as_mut_pin().poll_write_vectored(cx, bufs)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/src/common/handshake.rs
+++ b/src/common/handshake.rs
@@ -1,11 +1,12 @@
-use crate::common::{Stream, TlsState};
+use crate::common::{Stream, SyncWriteAdapter, TlsState};
+use futures_io::{AsyncRead, AsyncWrite};
+use rustls::server::AcceptedAlert;
 use rustls::{ConnectionCommon, SideData};
 use std::future::Future;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{io, mem};
-use futures_io::{AsyncRead, AsyncWrite};
 
 pub(crate) trait IoSession {
     type Io;
@@ -19,7 +20,15 @@ pub(crate) trait IoSession {
 pub(crate) enum MidHandshake<IS: IoSession> {
     Handshaking(IS),
     End,
-    Error { io: IS::Io, error: io::Error },
+    SendAlert {
+        io: IS::Io,
+        alert: AcceptedAlert,
+        error: io::Error,
+    },
+    Error {
+        io: IS::Io,
+        error: io::Error,
+    },
 }
 
 impl<IS, SD> Future for MidHandshake<IS>
@@ -36,6 +45,20 @@ where
 
         let mut stream = match mem::replace(this, MidHandshake::End) {
             MidHandshake::Handshaking(stream) => stream,
+            MidHandshake::SendAlert {
+                mut io,
+                mut alert,
+                error,
+            } => loop {
+                match alert.write(&mut SyncWriteAdapter { io: &mut io, cx }) {
+                    Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                        *this = MidHandshake::SendAlert { io, error, alert };
+                        return Poll::Pending;
+                    }
+                    Err(_) | Ok(0) => return Poll::Ready(Err((error, io))),
+                    Ok(_) => {}
+                };
+            },
             // Starting the handshake returned an error; fail the future immediately.
             MidHandshake::Error { io, error } => return Poll::Ready(Err((error, io))),
             _ => panic!("unexpected polling after handshake"),

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -299,6 +299,38 @@ where
         }
         Pin::new(&mut self.io).poll_close(cx)
     }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        if bufs.iter().all(|buf| buf.is_empty()) {
+            return Poll::Ready(Ok(0));
+        }
+
+        loop {
+            let mut would_block = false;
+            let written = self.session.writer().write_vectored(bufs)?;
+
+            while self.session.wants_write() {
+                match self.write_io(cx) {
+                    Poll::Ready(Ok(0)) | Poll::Pending => {
+                        would_block = true;
+                        break;
+                    }
+                    Poll::Ready(Ok(_)) => (),
+                    Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+                }
+            }
+
+            return match (written, would_block) {
+                (0, true) => Poll::Pending,
+                (0, false) => continue,
+                (n, _) => Poll::Ready(Ok(n)),
+            };
+        }
+    }
 }
 
 /// An adapter that implements a [`Read`] interface for [`AsyncRead`] types and an

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -297,7 +297,13 @@ where
         while self.session.wants_write() {
             ready!(self.write_io(cx))?;
         }
-        Pin::new(&mut self.io).poll_close(cx)
+
+        Poll::Ready(match ready!(Pin::new(&mut self.io).poll_close(cx)) {
+            Ok(()) => Ok(()),
+            // When trying to shutdown, not being connected seems fine
+            Err(err) if err.kind() == io::ErrorKind::NotConnected => Ok(()),
+            Err(err) => Err(err),
+        })
     }
 
     fn poll_write_vectored(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,4 +462,16 @@ where
             TlsStream::Server(x) => Pin::new(x).poll_close(cx),
         }
     }
+
+    #[inline]
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            TlsStream::Client(x) => Pin::new(x).poll_write_vectored(cx, bufs),
+            TlsStream::Server(x) => Pin::new(x).poll_write_vectored(cx, bufs),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Asynchronous TLS/SSL streams for futures using [Rustls](https://github.com/ctz/rustls).
+//! Asynchronous TLS/SSL streams for futures using [Rustls](https://github.com/rustls/rustls).
 
 macro_rules! ready {
     ( $e:expr ) => {
@@ -15,6 +15,7 @@ pub mod server;
 
 use common::{MidHandshake, Stream, TlsState};
 use futures_io::{AsyncRead, AsyncWrite};
+use rustls::server::AcceptedAlert;
 use rustls::{ClientConfig, ClientConnection, CommonState, ServerConfig, ServerConnection};
 use std::future::Future;
 use std::io;
@@ -26,8 +27,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-pub use rustls;
 pub use pki_types;
+pub use rustls;
 
 /// A wrapper around a `rustls::ClientConfig`, providing an async `connect` method.
 #[derive(Clone)]
@@ -78,7 +79,12 @@ impl TlsConnector {
         self.connect_with(domain, stream, |_| ())
     }
 
-    pub fn connect_with<IO, F>(&self, domain: pki_types::ServerName<'static>, stream: IO, f: F) -> Connect<IO>
+    pub fn connect_with<IO, F>(
+        &self,
+        domain: pki_types::ServerName<'static>,
+        stream: IO,
+        f: F,
+    ) -> Connect<IO>
     where
         IO: AsyncRead + AsyncWrite + Unpin,
         F: FnOnce(&mut ClientConnection),
@@ -155,6 +161,7 @@ impl TlsAcceptor {
 pub struct LazyConfigAcceptor<IO> {
     acceptor: rustls::server::Acceptor,
     io: Option<IO>,
+    alert: Option<(rustls::Error, AcceptedAlert)>,
 }
 
 impl<IO> LazyConfigAcceptor<IO>
@@ -166,6 +173,7 @@ where
         Self {
             acceptor,
             io: Some(io),
+            alert: None,
         }
     }
 }
@@ -189,6 +197,22 @@ where
                 }
             };
 
+            if let Some((err, mut alert)) = this.alert.take() {
+                match alert.write(&mut common::SyncWriteAdapter { io, cx }) {
+                    Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                        this.alert = Some((err, alert));
+                        return Poll::Pending;
+                    }
+                    Ok(0) | Err(_) => {
+                        return Poll::Ready(Err(io::Error::new(io::ErrorKind::InvalidData, err)))
+                    }
+                    Ok(_) => {
+                        this.alert = Some((err, alert));
+                        continue;
+                    }
+                };
+            }
+
             let mut reader = common::SyncReadAdapter { io, cx };
             match this.acceptor.read_tls(&mut reader) {
                 Ok(0) => return Err(io::ErrorKind::UnexpectedEof.into()).into(),
@@ -202,9 +226,9 @@ where
                     let io = this.io.take().unwrap();
                     return Poll::Ready(Ok(StartHandshake { accepted, io }));
                 }
-                Ok(None) => continue,
-                Err(err) => {
-                    return Poll::Ready(Err(io::Error::new(io::ErrorKind::InvalidInput, err)))
+                Ok(None) => {}
+                Err((err, alert)) => {
+                    this.alert = Some((err, alert));
                 }
             }
         }
@@ -234,12 +258,13 @@ where
     {
         let mut conn = match self.accepted.into_connection(config) {
             Ok(conn) => conn,
-            Err(error) => {
-                return Accept(MidHandshake::Error {
+            Err((error, alert)) => {
+                return Accept(MidHandshake::SendAlert {
                     io: self.io,
                     // TODO(eliza): should this really return an `io::Error`?
                     // Probably not...
                     error: io::Error::new(io::ErrorKind::Other, error),
+                    alert,
                 });
             }
         };
@@ -333,11 +358,11 @@ impl<T> TlsStream<T> {
         match self {
             Client(io) => {
                 let (io, session) = io.get_ref();
-                (io, &*session)
+                (io, session)
             }
             Server(io) => {
                 let (io, session) = io.get_ref();
-                (io, &*session)
+                (io, session)
             }
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,8 +1,3 @@
-#[cfg(unix)]
-use std::os::unix::io::{AsRawFd, RawFd};
-#[cfg(windows)]
-use std::os::windows::io::{AsRawSocket, RawSocket};
-
 use super::*;
 use crate::common::IoSession;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -119,6 +119,17 @@ where
             Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
         stream.as_mut_pin().poll_close(cx)
     }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        let mut stream =
+            Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
+        stream.as_mut_pin().poll_write_vectored(cx, bufs)
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
This PR is an attempt at updating futures-rustls for rustls 0.23.

* Switches the default crypto provider to `aws-lc-rs` to track rustls' default. (https://github.com/rustls/tokio-rustls/pull/50 for parity)
* Adds `fips` and `logging` features so crates don't need to depend on rustls just to enable those features without using rustls directly in code (https://github.com/rustls/tokio-rustls/pull/49 for parity)
* Sends AcceptedAlerts
  * ~Adds an optional AcceptedAlert to the MidHandshake::Error state~ Adds a SendAlert variant to MidHandshake per https://github.com/rustls/tokio-rustls/pull/44, with the changes in https://github.com/rustls/tokio-rustls/pull/47
  * Tracks an `Option<Error, AcceptedAlert>` on LazyConfigAcceptor in order to send the AcceptedAlert, tracking the changes in https://github.com/rustls/tokio-rustls/pull/48
* Adds a `pub(crate) common::SyncWriteAdapter` and uses it instead of an identical function-local `Writer` type, tracking the changes in https://github.com/rustls/tokio-rustls/pull/44
* Uses the existing `SyncReadAdapter` instead of an identical function-local `Reader` type tracking the changes in https://github.com/rustls/tokio-rustls/pull/44
* Addresses redundant-import compiler warnings introduced in a recent nightly
* Introduces several rustfmt-caused import order changes
* Updates a repository link to rustls/rustls
* Takes poll_vectored_write changes from https://github.com/rustls/tokio-rustls/pull/45
* Takes poll_close changes from https://github.com/rustls/tokio-rustls/pull/42
* Adds an aws_lc_rs alias for aws-lc-rs because some people use underscores for features and crate names

Let me know if you'd like me to split any of these out into distinct PRs or to back them out of this PR.