### PR TITLE
Cargo: 0.25.1 -> 0.26.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-rustls"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["quininer kel <quininer@live.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/quininer/futures-rustls"


### PR DESCRIPTION
Preparation to cut a new 0.26.0 release to bring in [changes since 0.25.1](https://github.com/rustls/futures-rustls/compare/ab57fb8d5e2150588564a0a55adab34f88e1ce53..791226255bdb8f3171b6c87ab541a3a167a3ce79).

This repo doesn't have an established CHANGELOG or GitHub releases, but the major callouts I would include would be:

## Additions

* Support for aws-lc-rs as the crypto backend
* Making aws-lc-rs the default crypto backend, matching rustls
* Support for Rustls 0.23 and the new acceptor alert API
* Support for passing through the fips feature with aws-lc-rs
* Support for forwarding vectored writes

## Fixes
* Ignoring `NotConnected` error in `poll_close` 

All of the above was contributed by @jbr in #9 based on similar 0.26.0 preparation work highlighted in https://github.com/rustls/tokio-rustls/pull/59